### PR TITLE
Bracket matcher

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -51,7 +51,7 @@ atom-text-editor, :host {
   }
   
   .bracket-matcher .region {
-    background-color: rgba(80, 80, 80, 0.5);
+    background-color: @bracket-background;
     border: 0;
   }
 

--- a/styles/base.less
+++ b/styles/base.less
@@ -51,8 +51,8 @@ atom-text-editor, :host {
   }
   
   .bracket-matcher .region {
-    background-color : rgba(80, 80, 80, 0.5);
-    border : 0;
+    background-color: rgba(80, 80, 80, 0.5);
+    border: 0;
   }
 
 }

--- a/styles/base.less
+++ b/styles/base.less
@@ -49,6 +49,12 @@ atom-text-editor, :host {
   .selection .region {
     background-color: @syntax-selection-color;
   }
+  
+  .bracket-matcher .region {
+    background-color : rgba(80, 80, 80, 0.5);
+    border : 0;
+  }
+
 }
 
 atom-text-editor .search-results .marker .region,

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -2,6 +2,8 @@
 // Atom theme inspired by a galaxy far far away...
 // By Jesse Leite.
 
+@bracket-background: hsla(0, 0%, 31%, 0.5);
+
 // Shades of the Millenium Falcon
 @very-light-grey: hsl(228, 7%, 81%);
 @light-grey: hsl(228, 7%, 55%);


### PR DESCRIPTION
I added a style rule to have a better fitting solution for bracket matching, since I really disliked the default green dots the 'bracket-matcher'-package provides. It changes the background color of a bracket to a transparent grey now by using color variables.
