### PR TITLE
Fix js `const` coloring

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -124,6 +124,10 @@ atom-text-editor .search-results .syntax--marker.current-result .region {
     &.syntax--var {
       color: @vader;
     }
+
+    &.syntax--const {
+      color: @vader;
+    }
   }
 
   &.syntax--modifier {


### PR DESCRIPTION
Atom seems to define `const` as `syntax--const` instead of `syntax--var`. Don't know if this is the right way to fix it but it annoyed me. If there's a better way (or no issue at all), let me know.

Checked on Atom 1.14.3